### PR TITLE
fix: skip global.js transform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export default function (opts: NodePolyfillsOptions = {}) {
 
     },
     transform(code: string, id: string) {
+      if(id === PREFIX + 'global.js') return
       return injectPlugin.transform.call(this, code, id.replace(PREFIX, resolve('node_modules', 'polyfill-node')));
     },
   };


### PR DESCRIPTION
### Description

Here is code of `global` ployfill, the code has `global` key words, it will transformed and add `import '\0polyfill-node:global.js'`. But it is a self import, so we need skip it.

``` js
export default (typeof global !== "undefined" ? global :
  typeof self !== "undefined" ? self :
  typeof window !== "undefined" ? window : {});
```