### PR TITLE
Type fix: implement plugin interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { Plugin } from "rollup";
 // @ts-ignore
 import inject from "@rollup/plugin-inject";
 import { getModules } from "./modules";
@@ -18,7 +19,7 @@ export interface NodePolyfillsOptions {
   exclude?: Array<string | RegExp> | string | RegExp | null;
 }
 
-export default function (opts: NodePolyfillsOptions = {}) {
+export default function (opts: NodePolyfillsOptions = {}): Plugin {
   const mods = getModules();
   const injectPlugin = inject({
     include: opts.include === undefined ? ['node_modules/**/*.js'] : opts.include,
@@ -36,7 +37,7 @@ export default function (opts: NodePolyfillsOptions = {}) {
   const dirs = new Map<string, string>();
   return {
     name: "polyfill-node",
-    resolveId(importee: string, importer: string) {
+    resolveId(importee: string, importer?: string) {
       if (importee === DIRNAME_PATH) {
         const id = getRandomId();
         dirs.set(id, dirname("/" + relative(basedir, importer)));


### PR DESCRIPTION
We're typechecking our rollup config, and TypeScript complained that `nodePolyfills()` is not conforming to the `Plugin` type, as the `importer` parameter of `resolveId` can be `undefined` (see [rollup](https://github.com/rollup/rollup/blob/66d2d82062c6b30adf5ec2a17e8483e393e0d7a8/src/rollup/types.d.ts#L367) [sources](https://github.com/rollup/rollup/blob/66d2d82062c6b30adf5ec2a17e8483e393e0d7a8/src/rollup/types.d.ts#L236-L241)).

Making the parameter optional appears to fix it, adding `Plugin` as a return type hopefully prevents similar issue from occurring in the future.