### PR TITLE
Polyfill modules that have already been transformed by commonjs plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ export default function (opts: NodePolyfillsOptions = {}): Plugin {
   return {
     name: "polyfill-node",
     resolveId(importee: string, importer?: string) {
+      if (importee[0] == '\0' && /\?commonjs-\w+$/.test(importee)) {
+        importee = importee.slice(1).replace(/\?commonjs-\w+$/, '');
+      }
       if (importee === DIRNAME_PATH) {
         const id = getRandomId();
         dirs.set(id, dirname("/" + relative(basedir, importer!)));


### PR DESCRIPTION
So when trying to polyfill in modules with Vite, I kept running into problems that certain libraries were still not receiving the polyfills. I finally traced it down to the fact that these modules were already transformed by the commonjs plugin, and thus tried to import the builtins as commonjs with the name `\0events?commonjs-<something>` for example. Since it has already been "processed" by the commonjs plugin, this plugin would ignore it.
So with this we can now tell the plugin to not ignore these modules and actually resolve them to the correct polyfill, but I'm not totally sure if we should be this direct. Should we also ignore other plugin-processed modules, or just the commonjs?

Also, to anyone else discovering this using Vite, you need to include this entire plugin under the normal `plugins` config option, not `build.rollupOptions.plugins`, as the latter will only use this plugin to resolve a single top level module, while the former will correctly use this plugin for every module resolution.