### PR TITLE
fix: 'homedir' is not exported by polyfill-node.os.js. issue #52

### DIFF
--- a/polyfills/os.js
+++ b/polyfills/os.js
@@ -100,7 +100,13 @@ export function tmpDir() {
 export var tmpdir = tmpDir;
 
 export var EOL = '\n';
+
+export function homedir(){
+  return '$HOME'
+}
+
 export default {
+  homedir: homedir,
   EOL: EOL,
   arch: arch,
   platform: platform,


### PR DESCRIPTION
fix: 'homedir' is not exported by polyfill-node.os.js  #52