### PR TITLE
Update url.js

### DIFF
--- a/polyfills/url.js
+++ b/polyfills/url.js
@@ -23,12 +23,21 @@
 import {toASCII} from 'punycode';
 import {isObject,isString,isNullOrUndefined,isNull} from 'util';
 import {parse as qsParse,stringify as qsStringify} from 'querystring';
+
+// WHATWG API
+const URL = global.URL;
+const URLSearchParams = global.URLSearchParams;
+
 export {
   urlParse as parse,
   urlResolve as resolve,
   urlResolveObject as resolveObject,
   urlFileURLToPath as fileURLToPath,
-  urlFormat as format
+  urlFormat as format,
+
+  // WHATWG API
+  URL,
+  URLSearchParams,  
 };
 export default {
   parse: urlParse,
@@ -36,7 +45,11 @@ export default {
   resolveObject: urlResolveObject,
   fileURLToPath: urlFileURLToPath,
   format: urlFormat,
-  Url: Url
+  Url: Url,
+
+  // WHATWG API
+  URL,
+  URLSearchParams,  
 }
 export function Url() {
   this.protocol = null;


### PR DESCRIPTION
This PR polyfills the [Node API](https://nodejs.org/api/url.html#the-whatwg-url-api) that implements the same [WHATWG URL Standard](https://url.spec.whatwg.org/) used by web browsers by, in rapturous cleverness, using the very same web browser implementation.