### PR TITLE
 add default export to buffer-es6.js module

### DIFF
--- a/polyfills/buffer-es6.js
+++ b/polyfills/buffer-es6.js
@@ -1980,4 +1980,4 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isFastBuffer(obj.slice(0, 0))
 }
 
-export { Buffer, INSPECT_MAX_BYTES, SlowBuffer, isBuffer, _kMaxLength as kMaxLength };
+export default { Buffer, INSPECT_MAX_BYTES, SlowBuffer, isBuffer, _kMaxLength as kMaxLength };


### PR DESCRIPTION
Fixes https://github.com/ionic-team/rollup-plugin-node-polyfills/issues/20