### PR TITLE
Handle inflate on buffer larger than chunk size 

### DIFF
--- a/polyfills/__zlib-lib/binding.js
+++ b/polyfills/__zlib-lib/binding.js
@@ -218,7 +218,7 @@ Zlib.prototype._write = function(flush, input, in_off, in_len, out, out_off, out
     throw new Error('Unknown mode ' + this.mode);
   }
 
-  if (!this._checkError(status)) {
+  if (!this._checkError(status, strm, flush)) {
     this._error(status);
   }
 
@@ -226,12 +226,12 @@ Zlib.prototype._write = function(flush, input, in_off, in_len, out, out_off, out
   return [strm.avail_in, strm.avail_out];
 };
 
-Zlib.prototype._checkError = function (status) {
+Zlib.prototype._checkError = function (status, strm, flush) {
   // Acceptable error states depend on the type of zlib stream.
   switch (status) {
     case Z_OK:
     case Z_BUF_ERROR:
-      if (this.strm.avail_out !== 0 && this.flush === Z_FINISH) {
+      if (strm.avail_out !== 0 && flush === Z_FINISH) {
         return false
       }
       break


### PR DESCRIPTION
# Issue

* In Zlib function `zlibBufferSync` :
** it tries to handle a given buffer
** the default chunkSize is 16384
** it calls zlib method `_processChunk`

* in Zlib method `_processChunk`
** there is a do-while loop calling `binding.writeSync` method to process the given buffer (parameter named `chunk`)
** the chunkSize options is used as available out memory
** the do-while loop calls a function `callback` that is supposed to handle the case where the available out memory is not enough
** the do-while loop breaks if there is an error in the writeSync process

* in Zlib method `writeSync`
** in calls `inflate` method and check returned status
** if the status is not OK, it marks an error, making the do-while loop breaks

* in `inflate` method:
** in case `MATCH`: if there is no memory left, it breaks the for-loop
** `ret` is Z_OK
** condition flush === Z_FINISH and ret === Z_OK is turning ret to Z_BUF_ERROR

As a consequence :
* status to Z_BUF_ERROR marks an error
* the do-while loop breaks
* the do-while loop does not handle the case where given buffer size is larger than chunk size option

# Proposal 

From: https://github.com/browserify/browserify-zlib/blob/master/src/binding.js#L241

* Check status after inflate
* if it is an Z_BUF_ERROR and no memory available, do not consider it has an error
* if so, the do-while loop in `_processChunk` can continue to handle large buffer
