### PR TITLE
fix: fix `node:` imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ export default function (opts: NodePolyfillsOptions = {}): Plugin {
       if (importee[0] == '\0' && /\?commonjs-\w+$/.test(importee)) {
         importee = importee.slice(1).replace(/\?commonjs-\w+$/, '');
       }
+      // Fix node: imports
+      if (importee.startsWith('node:')) {
+        importee = importee.replace('node:', '');
+      }
       if (importee === DIRNAME_PATH) {
         const id = getRandomId();
         dirs.set(id, dirname("/" + relative(basedir, importer!)));
@@ -73,7 +77,7 @@ export default function (opts: NodePolyfillsOptions = {}): Plugin {
       if (id.startsWith(PREFIX)) {
         const importee = id.substr(PREFIX_LENGTH).replace('.js', '');
         return mods.get(importee) || (POLYFILLS as any)[importee + '.js'];
-      } 
+      }
 
     },
     transform(code: string, id: string) {

--- a/test/examples/path.js
+++ b/test/examples/path.js
@@ -1,9 +1,10 @@
 import {dirname, relative} from 'path';
+import {sep} from 'node:path';
 
 
 var basedir = '/';
 var importer = './src/es6/path.js';
-var out = dirname('/' + relative(basedir, importer));
+var out = dirname(sep + relative(basedir, importer));
 if (out === '/src/es6'){
   done();
 } else {


### PR DESCRIPTION
Fixes imports like:

```js
import path from 'node:path'
```

fixes #84 