### PR TITLE
feat: add support for "node:" prefixed modules

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -57,5 +57,16 @@ export function getModules() {
   libs.set('tls', EMPTY_PATH);
   libs.set('perf_hooks', EMPTY_PATH);
 
+  // Add support for "node:" prefixed module
+  for (const libName of [...libs.keys()]) {
+    libs.set(`node:${libName}`, libs.get(libName) as string);
+  }
+
+  // Built-in modules with mandatory node: prefix
+  // https://nodejs.org/api/modules.html#built-in-modules-with-mandatory-node-prefix
+  libs.set('node:sea', EMPTY_PATH);
+  libs.set('node:test', EMPTY_PATH);
+  libs.set('node:test/reporters', EMPTY_PATH);
+
   return libs;
 }


### PR DESCRIPTION
This PR add support for the `node:` protocol.

It has the same goal as this other PR #85 but different implementation: here I just extend the list of modules by adding items to the libs Map while the other PR updates the importee in the plugins' resolveId. If there are a lot of modules to resolve, it might be slightly faster to get them from the libs Map and not go through if+startsWith+replace. Open to discussion which is best.

Closes #84 